### PR TITLE
derive parity-scale-codec an `MaxEncodedLen` for all types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@
   name = "typenum"
 
 [dependencies]
-  scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "2.3.1", default-features = false, features = ["derive", "max-encoded-len"], optional = true }
 
 [features]
-  derive_scale_info = ["scale-info"]
+  derive_scale = ["scale-info", "parity-scale-codec"]
   no_std = []
   i128 = []
   strict = []

--- a/src/array.rs
+++ b/src/array.rs
@@ -3,6 +3,7 @@
 //! It is not very featureful right now, and should be considered a work in progress.
 
 use core::ops::{Add, Div, Mul, Sub};
+#[cfg(feature = "derive_scale")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 use super::*;

--- a/src/array.rs
+++ b/src/array.rs
@@ -3,11 +3,15 @@
 //! It is not very featureful right now, and should be considered a work in progress.
 
 use core::ops::{Add, Div, Mul, Sub};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 use super::*;
 
 /// The terminating type for type arrays.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct ATerm;
 
@@ -19,7 +23,10 @@ impl TypeArray for ATerm {}
 ///
 /// This array is only really designed to contain `Integer` types. If you use it with others, you
 /// may find it lacking functionality.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct TArr<V, A> {
     first: V,

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -11,6 +11,7 @@
 
 use crate::{private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, PowerOfTwo, Zero};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
+#[cfg(feature = "derive_scale")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 pub use crate::marker_traits::Bit;

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -11,11 +11,15 @@
 
 use crate::{private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, PowerOfTwo, Zero};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 pub use crate::marker_traits::Bit;
 
 /// The type-level bit 0.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct B0;
 
@@ -28,7 +32,10 @@ impl B0 {
 }
 
 /// The type-level bit 1.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct B1;
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -35,6 +35,7 @@ use crate::{
     Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo, ToInt, Zero,
 };
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
+#[cfg(feature = "derive_scale")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 /// Type-level signed integers with positive sign.

--- a/src/int.rs
+++ b/src/int.rs
@@ -35,16 +35,23 @@ use crate::{
     Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo, ToInt, Zero,
 };
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 /// Type-level signed integers with positive sign.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct PInt<U: Unsigned + NonZero> {
     pub(crate) n: U,
 }
 
 /// Type-level signed integers with negative sign.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct NInt<U: Unsigned + NonZero> {
     pub(crate) n: U,
@@ -67,7 +74,10 @@ impl<U: Unsigned + NonZero> NInt<U> {
 }
 
 /// The type-level signed integer 0.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Z0;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 // trace_macros!(true);
 
 use core::cmp::Ordering;
+#[cfg(feature = "derive_scale")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 #[cfg(feature = "force_unix_path_separator")]
@@ -197,11 +198,9 @@ mod sealed {
 }
 
 #[cfg(test)]
+#[cfg(feature = "derive_scale")]
 mod tests {
-    use crate::{
-        bit::{B0, B1},
-        UInt, UTerm, U64,
-    };
+    use crate::U64;
     use scale_info::TypeInfo;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 // trace_macros!(true);
 
 use core::cmp::Ordering;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 #[cfg(feature = "force_unix_path_separator")]
 mod generated {
@@ -102,19 +103,28 @@ pub use crate::{
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Greater`.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Greater;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Less`.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Less;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Equal`.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Equal;
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -40,6 +40,7 @@ use crate::{
     SquareRoot, Sub1, Sum, ToInt, Zero,
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
+#[cfg(feature = "derive_scale")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 pub use crate::marker_traits::{PowerOfTwo, Unsigned};

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -40,12 +40,16 @@ use crate::{
     SquareRoot, Sub1, Sum, ToInt, Zero,
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 pub use crate::marker_traits::{PowerOfTwo, Unsigned};
 
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct UTerm;
 
@@ -143,7 +147,10 @@ impl Unsigned for UTerm {
 /// # #[allow(dead_code)]
 /// type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;
 /// ```
-#[cfg_attr(feature = "derive_scale_info", derive(scale_info::TypeInfo))]
+#[cfg_attr(
+    feature = "derive_scale",
+    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct UInt<U, B> {
     /// The more significant bits of `Self`.


### PR DESCRIPTION
* See https://github.com/encointer/pallets/issues/132