### PR TITLE
Derive `DecodeWithMemTracking` for everything

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@
   name = "substrate_typenum"
 
 [dependencies]
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"], optional = true }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"], optional = true }
+scale-info = { version = "2.11.6", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "3.7.4", default-features = false, features = ["derive", "max-encoded-len"], optional = true }
 
 [features]
   derive_scale = ["scale-info", "parity-scale-codec"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "substrate-typenum"
   build = "build/main.rs"
-  version = "1.16.0" # remember to update html_root_url
+  version = "1.17.0" # remember to update html_root_url
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>",

--- a/src/array.rs
+++ b/src/array.rs
@@ -4,14 +4,14 @@
 
 use core::ops::{Add, Div, Mul, Sub};
 #[cfg(feature = "derive_scale")]
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 
 use super::*;
 
 /// The terminating type for type arrays.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct ATerm;
@@ -26,7 +26,7 @@ impl TypeArray for ATerm {}
 /// may find it lacking functionality.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct TArr<V, A> {

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -12,14 +12,14 @@
 use crate::{private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, PowerOfTwo, Zero};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 #[cfg(feature = "derive_scale")]
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 
 pub use crate::marker_traits::Bit;
 
 /// The type-level bit 0.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct B0;
@@ -35,7 +35,7 @@ impl B0 {
 /// The type-level bit 1.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct B1;

--- a/src/int.rs
+++ b/src/int.rs
@@ -36,12 +36,12 @@ use crate::{
 };
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 #[cfg(feature = "derive_scale")]
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 
 /// Type-level signed integers with positive sign.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct PInt<U: Unsigned + NonZero> {
@@ -51,7 +51,7 @@ pub struct PInt<U: Unsigned + NonZero> {
 /// Type-level signed integers with negative sign.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct NInt<U: Unsigned + NonZero> {
@@ -77,7 +77,7 @@ impl<U: Unsigned + NonZero> NInt<U> {
 /// The type-level signed integer 0.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Z0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 
 use core::cmp::Ordering;
 #[cfg(feature = "derive_scale")]
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 
 #[cfg(feature = "force_unix_path_separator")]
 mod generated {
@@ -106,7 +106,7 @@ pub use crate::{
 /// `core::cmp::Ordering::Greater`.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Greater;
@@ -115,7 +115,7 @@ pub struct Greater;
 /// `core::cmp::Ordering::Less`.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Less;
@@ -124,7 +124,7 @@ pub struct Less;
 /// `core::cmp::Ordering::Equal`.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Equal;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 #[cfg(feature = "derive_scale")]
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 
 pub use crate::marker_traits::{PowerOfTwo, Unsigned};
 
@@ -49,7 +49,7 @@ pub use crate::marker_traits::{PowerOfTwo, Unsigned};
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct UTerm;
@@ -150,7 +150,7 @@ impl Unsigned for UTerm {
 /// ```
 #[cfg_attr(
     feature = "derive_scale",
-    derive(scale_info::TypeInfo, Decode, Encode, MaxEncodedLen)
+    derive(scale_info::TypeInfo, Decode, DecodeWithMemTracking, Encode, MaxEncodedLen)
 )]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct UInt<U, B> {


### PR DESCRIPTION
New parity-scale-codec trait that we need to implement.

I already tested that the pallets work with these fixes.

Todo:
- [x] release v1.17.0